### PR TITLE
feat: add node-only marker functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ import "es-only/deno";
 console.log(Deno.version);
 ```
 
+## node
+
+```ts
+import "es-only/node";
+
+console.log(process.version);
+```
+
 ## server-only
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "deno": "./src/empty.js",
       "default": "./src/deno.error.js"
     },
+    "./node": {
+      "node": "./src/empty.js",
+      "default": "./src/node.error.js"
+    },
     "./server-only": {
       "react-server": "./src/empty.js",
       "default": "./src/server-only.error.js"

--- a/src/node.error.js
+++ b/src/node.error.js
@@ -1,0 +1,1 @@
+throw new Error("This module must be used with Node.js.");


### PR DESCRIPTION
## Summary
- Add node-only marker that restricts module usage to Node.js environments only
- Follows the same pattern as existing bun-only, deno-only, and server-only markers
- Throws descriptive error when imported from non-Node.js environments

## Changes
- **src/node.error.js**: New error file that throws when imported outside Node.js
- **package.json**: Added `"./node"` export with Node.js conditional export
- **README.md**: Added documentation and usage example for node-only marker

## Usage
```ts
import "es-only/node";

console.log(process.version); // Only works in Node.js
```

## Test plan
- [ ] Verify import works correctly in Node.js environment
- [ ] Verify import throws error in Bun environment  
- [ ] Verify import throws error in Deno environment
- [ ] Verify import throws error in browser environment