### PR TITLE
feat: add browser-only marker functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # es-only
 
 
+## browser
+
+```ts
+import "es-only/browser";
+
+console.log(window.location.href);
+```
+
 ## bun
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Runtime-specific imports for modern JavaScript environments - Bun, Deno, Node.js, server-only, and more",
   "type": "module",
   "exports": {
+    "./browser": {
+      "browser": "./src/empty.js",
+      "default": "./src/browser.error.js"
+    },
     "./bun": {
       "bun": "./src/empty.js",
       "default": "./src/bun.error.js"

--- a/src/browser.error.js
+++ b/src/browser.error.js
@@ -1,0 +1,1 @@
+throw new Error("This module must be used in a browser environment.");


### PR DESCRIPTION
## Summary
- Add browser-only marker that restricts module usage to browser environments only
- Follows the same pattern as existing bun-only, deno-only, node-only, and server-only markers
- Throws descriptive error when imported from non-browser environments

## Changes
- **src/browser.error.js**: New error file that throws when imported outside browser environment
- **package.json**: Added `"./browser"` export with browser conditional export
- **README.md**: Added documentation and usage example for browser-only marker

## Usage
```ts
import "es-only/browser";

console.log(window.location.href); // Only works in browser environment
```

## Test plan
- [ ] Verify import works correctly in browser environment
- [ ] Verify import throws error in Node.js environment
- [ ] Verify import throws error in Bun environment  
- [ ] Verify import throws error in Deno environment
- [ ] Verify import throws error in server-side environments